### PR TITLE
Fixed rollback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Version 0.5.1 (2024-02-23)
+
+* Fixed rollback for situations where writing to Zarr fails shortly after the
+  Zarr directory has been created. [#69]
+  
+  In this case the error message was
+  ```TypeError: Transaction._delete_dir() missing 1 required positional argument: 'target_path'```. 
+
+
 ## Version 0.5.0 (2024-02-19)
 
 ### Enhancements

--- a/zappend/__init__.py
+++ b/zappend/__init__.py
@@ -2,4 +2,4 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
Fixed rollback for situations where writing to Zarr fails shortly after the Zarr directory has been created. 

Closes #69
  
Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [x] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [ ] ~Added docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~Changes/features documented in `docs/*`~
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
