### PR TITLE
Made writing custom slice sources easier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+## Version 0.7.0 (in development)
+
+* Made writing custom slice sources easier: (#82)
+
+  - Slice items can now be a `contextlib.AbstractContextManager` 
+    so custom slice functions can now be used with
+    [@contextlib.contextmanager](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager).
+  
+  - Introduced `SliceSource.close()` so
+    [contextlib.closing()](https://docs.python.org/3/library/contextlib.html#contextlib.closing)
+    is applicable. Deprecated `SliceSource.dispose()`.
+
 ## Version 0.6.0 (from 2024-03-12)
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ The `zappend` tool provides the following features:
   [`zappend`](cli.md) command or from Python. When used from Python using the 
   [`zappend()`](api.md) function, slice datasets can be passed as local file 
   paths, URIs, as datasets of type 
-  [xarray.Dataset](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.html), or as custom 
-  [zappend.api.SliceSource](https://bcdev.github.io/zappend/api/#class-slicesource) objects.
+  [xarray.Dataset](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.html), or as custom
+  [slice sources](https://bcdev.github.io/zappend/guide/#slice-sources).
 
   
 More about zappend can be found in its 

--- a/docs/config.md
+++ b/docs/config.md
@@ -193,7 +193,7 @@ Options for the filesystem given by the URI of `target_dir`.
 ## `slice_source`
 
 Type _string_.
-The fully qualified name of a class or function that provides a slice source for each slice item. If a class is given, it must be  derived from `zappend.api.SliceSource`. If a function is given, it must return an instance of  `zappend.api.SliceSource`. Refer to the user guide for more information.
+The fully qualified name of a class or function that receives a slice item as argument(s) and provides the slice dataset. If a class is given, it must be derived from `zappend.api.SliceSource`. If the function is a context manager, it must yield an `xarray.Dataset`. If a plain function is given, it must return any valid slice item type. Refer to the user guide for more information.
 
 ## `slice_engine`
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -699,7 +699,7 @@ The `SliceSource` methods with special meaning are:
 * `get_dataset()`: a zero-argument method that returns the slice dataset of type 
   `xarray.Dataset`. You must implement this abstract method. 
 * `close()`: perform any resource cleanup tasks 
-  (in zappend < v0.7, the `close` methods was called `dispose`).
+  (in zappend < v0.7, the `close` method was called `dispose`).
 * `__init__()`: optional constructor that receives any arguments passed to the 
   slice source.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,8 +39,8 @@ The `zappend` tool provides the following features:
   [`zappend`](cli.md) command or from Python. When used from Python using the 
   [`zappend()`](api.md) function, slice datasets can be passed as local file 
   paths, URIs, as datasets of type 
-  [xarray.Dataset](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.html), or as custom 
-  [zappend.api.SliceSource](https://bcdev.github.io/zappend/api/#class-slicesource) objects.
+  [xarray.Dataset](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.html), or as custom
+  [slice sources](guide#slice-sources).
 
 ## How It Works
 

--- a/tests/slice/test_cm.py
+++ b/tests/slice/test_cm.py
@@ -35,6 +35,7 @@ class OpenSliceDatasetTest(unittest.TestCase):
         ctx = Context(dict(target_dir="memory://target.zarr"))
         slice_item = MemorySliceSource(dataset, 0)
         slice_cm = open_slice_dataset(ctx, slice_item)
+        self.assertIsInstance(slice_cm, SliceSourceContextManager)
         self.assertIs(slice_item, slice_cm.slice_source)
 
     def test_slice_item_is_dataset(self):

--- a/zappend/__init__.py
+++ b/zappend/__init__.py
@@ -2,4 +2,4 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.6.0"
+__version__ = "0.7.0.dev0"

--- a/zappend/api.py
+++ b/zappend/api.py
@@ -45,14 +45,22 @@ def zappend(
     This ensures integrity of the  target data cube `target_dir` given
     in `config` or `kwargs`.
 
+    Each slice item in `slices` provides a slice dataset to be appended.
+    The interpretation of a given slice item depends on whether a slice source
+    is configured or not (setting `slice_source`).
+
+    If no slice source is configured, a slice item must be an object of type
+    `str`, `FileObj`, `xarray.Dataset`, or `SliceSource`.
+    If `str` or `FileObj` are used, they are interpreted as local dataset path or
+    dataset URI. If a URI is used, protocol-specific parameters apply, given by the
+    configuration parameter `slice_storage_options`.
+
+    If a slice source is configured, a slice item represents the argument(s) passed
+    to that slice source. Multiple positional arguments can be passed as `list`,
+    multiple keyword arguments as `dict`, and both as a `tuple` of `list` and `dict`.
+
     Args:
-        slices: An iterable that yields slice items. A slice item is
-            either a `str`, `FileObj`, `xarray.Dataset`, `SliceSource`,
-            or represents arguments passed to a configured `slice_source`.
-            If `str` or `FileObj` are used, they are interpreted as
-            local dataset path or dataset URI.
-            If a URI is used, protocol-specific parameters apply, given by
-            configuration parameter `slice_storage_options`.
+        slices: An iterable that yields slice items.
         config: Processor configuration.
             May be a file path or URI, a `dict`, `None`, or a sequence of
             the aforementioned. If a sequence is used, subsequent

--- a/zappend/config/config.py
+++ b/zappend/config/config.py
@@ -122,9 +122,14 @@ class Config:
 
     @property
     def slice_source(self) -> Callable[[...], Any] | None:
-        """The configured slice source type. If given, it must be
-        a callable that returns a value of type `SliceItem` or a class that is
-        derived from `SliceSource` abstract base class.
+        """A class or function that receives a
+        slice item as argument(s) and provides the slice dataset.
+
+        * If a class is given, it must be derived from `zappend.api.SliceSource`.
+        * If the function is a context manager, it must yield an `xarray.Dataset`.
+        * If a plain function is given, it must return any valid slice item type.
+
+        Refer to the user guide for more information.
         """
         return self._slice_source
 

--- a/zappend/config/schema.py
+++ b/zappend/config/schema.py
@@ -630,11 +630,14 @@ CONFIG_SCHEMA_V1 = {
         },
         slice_source={
             "description": (
-                "The fully qualified name of a class or function that provides"
-                " a slice source for each slice item. If a class is given, it must be "
-                " derived from `zappend.api.SliceSource`."
-                " If a function is given, it must return an instance of "
-                " `zappend.api.SliceSource`."
+                "The fully qualified name of a class or function that receives a"
+                " slice item as argument(s) and provides the slice dataset."
+                " If a class is given,"
+                " it must be derived from `zappend.api.SliceSource`."
+                " If the function is a context manager,"
+                " it must yield an `xarray.Dataset`."
+                " If a plain function is given,"
+                " it must return any valid slice item type."
                 " Refer to the user guide for more information."
             ),
             "type": "string",

--- a/zappend/slice/source.py
+++ b/zappend/slice/source.py
@@ -2,8 +2,10 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
+import contextlib
+import warnings
 from abc import abstractmethod, ABC
-from typing import Callable, Type
+from typing import Callable, ContextManager, Type
 
 import xarray as xr
 
@@ -14,11 +16,11 @@ from zappend.fsutil import FileObj
 class SliceSource(ABC):
     """Slice source interface definition.
 
-    A slice source is a disposable source for a slice dataset.
+    A slice source is a closable source for a slice dataset.
 
     A slice source is intended to be implemented by users. An implementation
     must provide the methods [get_dataset()][zappend.slice.abc.SliceSource.get_dataset]
-    and [dispose()][zappend.slice.abc.SliceSource.dispose].
+    and [close()][zappend.slice.abc.SliceSource.dispose].
 
     If your slice source class requires the processing context,
     your class constructor may define a `ctx: Context` as 1st positional
@@ -44,21 +46,31 @@ class SliceSource(ABC):
             A slice dataset.
         """
 
-    @abstractmethod
-    def dispose(self):
-        """Dispose this slice source.
+    def close(self):
+        """Close this slice source.
         This should include cleaning up of any temporary resources.
 
         This method is not intended to be called directly
         and is called exactly once for each instance of this class.
         """
+        if hasattr(self, "dispose"):
+            warnings.warn(
+                "The dispose() method of SliceSource has been"
+                " deprecated since zappend 0.6.0,"
+                " please override close() instead.",
+                category=DeprecationWarning,
+            )
+            self.dispose()
+
+    def dispose(self):
+        """Deprecated since version 0.6.0, override [close()][close] instead."""
 
 
-SliceItem = str | FileObj | xr.Dataset | SliceSource
+SliceItem = str | FileObj | xr.Dataset | ContextManager[xr.Dataset] | SliceSource
 """The possible types that can represent a slice dataset."""
 
 SliceCallable = Type[SliceSource] | Callable[[...], SliceItem]
-"""This type that is either a class derived from `SliceSource` 
+"""This type is either a class derived from `SliceSource` 
 or a function that returns a `SliceItem`. Both can be invoked
 with any number of positional or keyword arguments. The processing 
 context, if used, is passed either as 1st positional argument or 
@@ -71,7 +83,7 @@ def to_slice_source(
     ctx: Context,
     slice_item: SliceItem,
     slice_index: int,
-) -> SliceSource:
+) -> SliceSource | ContextManager[xr.Dataset]:
     # prevent cyclic import
     from .sources import MemorySliceSource
     from .sources import PersistentSliceSource
@@ -96,10 +108,13 @@ def to_slice_source(
             return TemporarySliceSource(ctx, slice_item, slice_index)
         else:
             return MemorySliceSource(slice_item, slice_index)
+    if isinstance(slice_item, contextlib.AbstractContextManager):
+        return slice_item
     raise TypeError(
         f"slice_item must have type"
         f" str,"
         f" xarray.Dataset,"
+        f" contextlib.AbstractContextManager,"
         f" zappend.api.FileObj,"
         f" zappend.api.SliceSource,"
         f" but was type {type(slice_item).__name__}"

--- a/zappend/slice/source.py
+++ b/zappend/slice/source.py
@@ -19,8 +19,8 @@ class SliceSource(ABC):
     A slice source is a closable source for a slice dataset.
 
     A slice source is intended to be implemented by users. An implementation
-    must provide the methods [get_dataset()][zappend.slice.abc.SliceSource.get_dataset]
-    and [close()][zappend.slice.abc.SliceSource.dispose].
+    must provide the methods [get_dataset()][zappend.api.SliceSource.get_dataset]
+    and [close()][zappend.api.SliceSource.close].
 
     If your slice source class requires the processing context,
     your class constructor may define a `ctx: Context` as 1st positional
@@ -63,7 +63,9 @@ class SliceSource(ABC):
             self.dispose()
 
     def dispose(self):
-        """Deprecated since version 0.6.0, override [close()][close] instead."""
+        """Deprecated since version 0.6.0, override
+        [close()][zappend.api.SliceSource.close] instead.
+        """
 
 
 SliceItem = str | FileObj | xr.Dataset | ContextManager[xr.Dataset] | SliceSource

--- a/zappend/slice/sources/memory.py
+++ b/zappend/slice/sources/memory.py
@@ -24,6 +24,6 @@ class MemorySliceSource(SliceSource):
         logger.info(f"Processing in-memory slice dataset #{self._slice_index}")
         return self._slice_ds
 
-    def dispose(self):
+    def close(self):
         self._slice_ds = None
         logger.info(f"Slice dataset #{self._slice_index} processed")

--- a/zappend/slice/sources/persistent.py
+++ b/zappend/slice/sources/persistent.py
@@ -32,12 +32,11 @@ class PersistentSliceSource(SliceSource):
         self._slice_ds = self._wait_for_slice_dataset()
         return self._slice_ds
 
-    def dispose(self):
+    def close(self):
         if self._slice_ds is not None:
             self._slice_ds.close()
             self._slice_ds = None
         logger.info(f"Slice dataset {self._slice_file.uri} closed")
-        super().dispose()
 
     def _wait_for_slice_dataset(self) -> xr.Dataset:
         interval, timeout = self._config.slice_polling

--- a/zappend/slice/sources/temporary.py
+++ b/zappend/slice/sources/temporary.py
@@ -42,7 +42,7 @@ class TemporarySliceSource(MemorySliceSource):
         self._temp_slice_ds = xr.open_zarr(temp_slice_store)
         return self._temp_slice_ds
 
-    def dispose(self):
+    def close(self):
         if self._temp_slice_ds is not None:
             self._temp_slice_ds.close()
             self._temp_slice_ds = None
@@ -57,4 +57,4 @@ class TemporarySliceSource(MemorySliceSource):
                 )
                 temp_slice_dir.delete(recursive=True)
 
-        super().dispose()
+        super().close()


### PR DESCRIPTION
* Slice items can now be a `contextlib.AbstractContextManager` so custom slice functions can now be used with  `@contextlib.contextmanager`.
* Deprecated `SliceSource.dispose()` and introduced `SliceSource.close()`.

To close #82, also see #84 and #86.

Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [x] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [x] Added docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes/features documented in `docs/*`
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
