### PR TITLE
New configuration setting `slice_source_kwargs` 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
     is applicable. Deprecated `SliceSource.dispose()`.
     
   - Introduced new optional configuration setting `slice_source_kwargs` that
-    contains keyword-arguments passed to a configured `slice_source` together with 
+    contains keyword-arguments, which are passed to a configured `slice_source` together with 
     each slice item.
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
   - Introduced `SliceSource.close()` so
     [contextlib.closing()](https://docs.python.org/3/library/contextlib.html#contextlib.closing)
     is applicable. Deprecated `SliceSource.dispose()`.
+    
+  - Introduced new optional configuration setting `slice_source_kwargs` that
+    contains keyword-arguments passed to a configured `slice_source` together with 
+    each slice item.
+
 
 ## Version 0.6.0 (from 2024-03-12)
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -760,6 +760,11 @@ argument to your slice source.
     - `dict`: keyword arguments only;
     - Any other type is interpreted as single positional argument.
 
+You can also pass extra keyword arguments to your slice source using the 
+`slice_source_kwargs` setting. Its properties are passed as keyword arguments to 
+every slice source invocation. Keyword arguments passed as slice items with same name
+as in `slice_source_kwargs` take precedence.
+
 In addition, your slice source function or class constructor specified by 
 `slice_source` may define a 1st positional argument or keyword argument 
 named `ctx`, which will receive the current processing context of type 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -761,9 +761,8 @@ argument to your slice source.
     - Any other type is interpreted as single positional argument.
 
 You can also pass extra keyword arguments to your slice source using the 
-`slice_source_kwargs` setting. Its properties are passed as keyword arguments to 
-every slice source invocation. Keyword arguments passed as slice items with same name
-as in `slice_source_kwargs` take precedence.
+`slice_source_kwargs` setting. Keyword arguments passed as slice items take 
+precedence, that is, they overwrite arguments passed by `slice_source_kawrgs`.
 
 In addition, your slice source function or class constructor specified by 
 `slice_source` may define a 1st positional argument or keyword argument 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -162,6 +162,24 @@ class ConfigTest(unittest.TestCase):
                 }
             )
 
+    def test_slice_source_kwargs(self):
+        config = Config(
+            {
+                "target_dir": "memory://target.zarr",
+            }
+        )
+        self.assertEqual(None, config.slice_source_kwargs)
+
+        config = Config(
+            {
+                "target_dir": "memory://target.zarr",
+                "slice_source_kwargs": {"a": 1, "b": True, "c": "nearest"},
+            }
+        )
+        self.assertEqual(
+            {"a": 1, "b": True, "c": "nearest"}, config.slice_source_kwargs
+        )
+
 
 def new_custom_slice_source(ctx: Context, index: int):
     return CustomSliceSource(ctx, index)

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -31,6 +31,7 @@ class ConfigSchemaTest(unittest.TestCase):
                 "slice_engine",
                 "slice_polling",
                 "slice_source",
+                "slice_source_kwargs",
                 "slice_storage_options",
                 "target_storage_options",
                 "target_dir",

--- a/tests/slice/test_cm.py
+++ b/tests/slice/test_cm.py
@@ -241,8 +241,8 @@ class OpenSliceDatasetTest(unittest.TestCase):
         self.assertIsInstance(slice_source, MySliceSource)
         with slice_cm as slice_ds:
             self.assertIsInstance(slice_ds, xr.Dataset)
-            self.assertEquals(slice_source.args, ("bibo",))
-            self.assertEquals(
+            self.assertEqual(slice_source.args, ("bibo",))
+            self.assertEqual(
                 slice_source.kwargs, {"a": 2, "b": True, "c": "nearest", "d": 3.14}
             )
 

--- a/zappend/config/config.py
+++ b/zappend/config/config.py
@@ -135,7 +135,7 @@ class Config:
 
     @property
     def slice_source_kwargs(self) -> dict[str, Any] | None:
-        """Extra keyword-arguments passed to a configured `slice_source`
+        """Extra keyword-arguments passed to a specified `slice_source`
         together with each slice item.
         """
         return self._config.get("slice_source_kwargs")

--- a/zappend/config/config.py
+++ b/zappend/config/config.py
@@ -129,6 +129,13 @@ class Config:
         return self._slice_source
 
     @property
+    def slice_source_kwargs(self) -> dict[str, Any] | None:
+        """Extra keyword-arguments passed to a configured `slice_source`
+        together with each slice item.
+        """
+        return self._config.get("slice_source_kwargs")
+
+    @property
     def slice_storage_options(self) -> dict[str, Any] | None:
         """The configured slice storage options to be used
         if a slice item is a URI.

--- a/zappend/config/schema.py
+++ b/zappend/config/schema.py
@@ -643,6 +643,14 @@ CONFIG_SCHEMA_V1 = {
             "type": "string",
             "minLength": 1,
         },
+        slice_source_kwargs={
+            "description": (
+                "Extra keyword-arguments passed to a configured `slice_source`"
+                " together with each slice item."
+            ),
+            "type": "object",
+            "additionalProperties": True,
+        },
         slice_engine={
             "description": (
                 "The name of the engine to be used for opening"

--- a/zappend/slice/callable.py
+++ b/zappend/slice/callable.py
@@ -30,6 +30,10 @@ def invoke_slice_callable(
         A slice item of type `SliceItem`.
     """
     slice_args, slice_kwargs = to_slice_args(slice_item)
+    if ctx.config.slice_source_kwargs:
+        extra_kwargs = dict(ctx.config.slice_source_kwargs)
+        extra_kwargs.update(slice_kwargs)
+        slice_kwargs = extra_kwargs
 
     signature = inspect.signature(slice_callable)
     ctx_parameter = signature.parameters.get("ctx")


### PR DESCRIPTION
Addresses #82. To close, see #86.

Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [x] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [x] Added docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes/features documented in `docs/*`
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
